### PR TITLE
Use the mjml api to convert mjml to html

### DIFF
--- a/src/mjml/mjml.service.js
+++ b/src/mjml/mjml.service.js
@@ -46,7 +46,11 @@ export default class MjmlService {
    * @todo show validation erros in the UI
    * @returns string
    */
-  static mjmlToHtml(mjml) {
+  static mjmlToHtml(mjml, endpoint = null, token = null) {
+    if (endpoint !== null && token !== null) {
+      return MjmlService.mjmlToHtmlViaEndpoint(mjml, endpoint, token);
+    }
+
     try {
       if (typeof mjml !== 'string' || !mjml.includes('<mjml>')) {
         throw new Error('No valid MJML provided');
@@ -59,5 +63,20 @@ export default class MjmlService {
       console.warn(error);
       return null;
     }
+  }
+
+  /**
+   * Transform MJML to HTML via endpoint
+   * @returns string|null
+   */
+  static mjmlToHtmlViaEndpoint(mjml, endpoint, token) {
+    const xmlHttpRequest = new XMLHttpRequest();
+    xmlHttpRequest.open('POST', endpoint, false);
+    xmlHttpRequest.setRequestHeader('Content-type', 'application/json');
+    xmlHttpRequest.setRequestHeader('Access-Token', token);
+    xmlHttpRequest.send(JSON.stringify({ mjml }));
+    const result = JSON.parse(xmlHttpRequest.responseText);
+
+    return result.html ?? null;
   }
 }

--- a/src/mjml/mjml.service.js
+++ b/src/mjml/mjml.service.js
@@ -46,15 +46,16 @@ export default class MjmlService {
    * @todo show validation erros in the UI
    * @returns string
    */
-  static mjmlToHtml(mjml, endpoint = null) {
-    if (endpoint !== null) {
+  static mjmlToHtml(mjml, endpoint = '') {
+    if (typeof mjml !== 'string' || !mjml.includes('<mjml>')) {
+      throw new Error('No valid MJML provided');
+    }
+
+    if (endpoint !== '') {
       return MjmlService.mjmlToHtmlViaEndpoint(mjml, endpoint);
     }
 
     try {
-      if (typeof mjml !== 'string' || !mjml.includes('<mjml>')) {
-        throw new Error('No valid MJML provided');
-      }
       // html needs to be beautified for the click tracking to work.
       // strict mode not working with e.g. id="" and data-type parameters that
       // are e.g. used for Dynamic Content

--- a/src/mjml/mjml.service.js
+++ b/src/mjml/mjml.service.js
@@ -43,8 +43,8 @@ export default class MjmlService {
 
   /**
    * Transform MJML to HTML
-   * @todo show validation erros in the UI
-   * @returns string
+   * @todo show validation errors in the UI
+   * @returns ?string
    */
   static mjmlToHtml(mjml, endpoint = '') {
     if (typeof mjml !== 'string' || !mjml.includes('<mjml>')) {
@@ -71,6 +71,7 @@ export default class MjmlService {
    * @returns string|null
    */
   static mjmlToHtmlViaEndpoint(mjml, endpoint) {
+    console.log(endpoint);
     const xmlHttpRequest = new XMLHttpRequest();
     xmlHttpRequest.open('POST', endpoint, false);
     xmlHttpRequest.setRequestHeader('Content-type', 'application/json');

--- a/src/mjml/mjml.service.js
+++ b/src/mjml/mjml.service.js
@@ -46,9 +46,9 @@ export default class MjmlService {
    * @todo show validation erros in the UI
    * @returns string
    */
-  static mjmlToHtml(mjml, endpoint = null, token = null) {
-    if (endpoint !== null && token !== null) {
-      return MjmlService.mjmlToHtmlViaEndpoint(mjml, endpoint, token);
+  static mjmlToHtml(mjml, endpoint = null) {
+    if (endpoint !== null) {
+      return MjmlService.mjmlToHtmlViaEndpoint(mjml, endpoint);
     }
 
     try {
@@ -69,14 +69,12 @@ export default class MjmlService {
    * Transform MJML to HTML via endpoint
    * @returns string|null
    */
-  static mjmlToHtmlViaEndpoint(mjml, endpoint, token) {
+  static mjmlToHtmlViaEndpoint(mjml, endpoint) {
     const xmlHttpRequest = new XMLHttpRequest();
     xmlHttpRequest.open('POST', endpoint, false);
     xmlHttpRequest.setRequestHeader('Content-type', 'application/json');
-    xmlHttpRequest.setRequestHeader('Access-Token', token);
     xmlHttpRequest.send(JSON.stringify({ mjml }));
-    const result = JSON.parse(xmlHttpRequest.responseText);
 
-    return result.html ?? null;
+    return xmlHttpRequest.responseText ? JSON.parse(xmlHttpRequest.responseText) : null;
   }
 }

--- a/src/mjml/mjml.service.js
+++ b/src/mjml/mjml.service.js
@@ -44,26 +44,29 @@ export default class MjmlService {
   /**
    * Transform MJML to HTML
    * @todo show validation errors in the UI
-   * @returns ?string
+   * @returns string
    */
   static mjmlToHtml(mjml, endpoint = '') {
-    if (typeof mjml !== 'string' || !mjml.includes('<mjml>')) {
-      throw new Error('No valid MJML provided');
-    }
-
-    if (endpoint !== '') {
-      return MjmlService.mjmlToHtmlViaEndpoint(mjml, endpoint);
-    }
+    let html = '';
 
     try {
-      // html needs to be beautified for the click tracking to work.
-      // strict mode not working with e.g. id="" and data-type parameters that
-      // are e.g. used for Dynamic Content
-      return mjml2html(mjml, { beautify: true });
+      if (typeof mjml !== 'string' || !mjml.includes('<mjml>')) {
+        throw new Error('No valid MJML provided');
+      }
+
+      if (endpoint !== '') {
+        html = MjmlService.mjmlToHtmlViaEndpoint(mjml, endpoint);
+      } else {
+        // html needs to be beautified for the click tracking to work.
+        // strict mode not working with e.g. id="" and data-type parameters that
+        // are e.g. used for Dynamic Content
+        html = mjml2html(mjml, { beautify: true });
+      }
     } catch (error) {
       console.warn(error);
-      return null;
     }
+
+    return html;
   }
 
   /**
@@ -71,7 +74,6 @@ export default class MjmlService {
    * @returns string|null
    */
   static mjmlToHtmlViaEndpoint(mjml, endpoint) {
-    console.log(endpoint);
     const xmlHttpRequest = new XMLHttpRequest();
     xmlHttpRequest.open('POST', endpoint, false);
     xmlHttpRequest.setRequestHeader('Content-type', 'application/json');

--- a/src/mjml/mjml.service.js
+++ b/src/mjml/mjml.service.js
@@ -71,7 +71,7 @@ export default class MjmlService {
 
   /**
    * Transform MJML to HTML via endpoint
-   * @returns string|null
+   * @returns string
    */
   static mjmlToHtmlViaEndpoint(mjml, endpoint) {
     const xmlHttpRequest = new XMLHttpRequest();
@@ -79,6 +79,6 @@ export default class MjmlService {
     xmlHttpRequest.setRequestHeader('Content-type', 'application/json');
     xmlHttpRequest.send(JSON.stringify({ mjml }));
 
-    return xmlHttpRequest.responseText ? JSON.parse(xmlHttpRequest.responseText) : null;
+    return xmlHttpRequest.responseText ? JSON.parse(xmlHttpRequest.responseText) : '';
   }
 }


### PR DESCRIPTION
Fixes [Email Builder uses the MJML API to convert MJML to HTML](https://trello.com/c/zmegsH3P/217-email-builder-uses-the-mjml-api-to-convert-mjml-to-html)